### PR TITLE
Bump shiro-spring in /11.Spring-Boot-Shiro-Authentication

### DIFF
--- a/11.Spring-Boot-Shiro-Authentication/pom.xml
+++ b/11.Spring-Boot-Shiro-Authentication/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 		    <groupId>org.apache.shiro</groupId>
 		    <artifactId>shiro-spring</artifactId>
-		    <version>1.4.0</version>
+		    <version>1.7.0</version>
 		</dependency>
 		
 		


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.0.

Signed-off-by: dependabot[bot] <support@github.com>