### PR TITLE
Bump shiro-spring in /12.Spring-Boot-Shiro-RememberMe

### DIFF
--- a/12.Spring-Boot-Shiro-RememberMe/pom.xml
+++ b/12.Spring-Boot-Shiro-RememberMe/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 		    <groupId>org.apache.shiro</groupId>
 		    <artifactId>shiro-spring</artifactId>
-		    <version>1.4.0</version>
+		    <version>1.7.0</version>
 		</dependency>
 		
 		


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.0.

Signed-off-by: dependabot[bot] <support@github.com>