### PR TITLE
Bump shiro-spring in /13.Spring-Boot-Shiro-Authorization

### DIFF
--- a/13.Spring-Boot-Shiro-Authorization/pom.xml
+++ b/13.Spring-Boot-Shiro-Authorization/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 		    <groupId>org.apache.shiro</groupId>
 		    <artifactId>shiro-spring</artifactId>
-		    <version>1.4.0</version>
+		    <version>1.7.0</version>
 		</dependency>
 		
 		


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.0.

Signed-off-by: dependabot[bot] <support@github.com>