### PR TITLE
Bump shiro-spring from 1.4.0 to 1.7.0 in /14.Spring-Boot-Shiro-Redis

### DIFF
--- a/14.Spring-Boot-Shiro-Redis/pom.xml
+++ b/14.Spring-Boot-Shiro-Redis/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 		    <groupId>org.apache.shiro</groupId>
 		    <artifactId>shiro-spring</artifactId>
-		    <version>1.4.0</version>
+		    <version>1.7.0</version>
 		</dependency>
 		
 		<!-- shiro-redis -->


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.0.

Signed-off-by: dependabot[bot] <support@github.com>