### PR TITLE
Bump shiro-spring from 1.4.0 to 1.7.0 in /15.Spring-Boot-Shiro-Ehcache

### DIFF
--- a/15.Spring-Boot-Shiro-Ehcache/pom.xml
+++ b/15.Spring-Boot-Shiro-Ehcache/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 		    <groupId>org.apache.shiro</groupId>
 		    <artifactId>shiro-spring</artifactId>
-		    <version>1.4.0</version>
+		    <version>1.7.0</version>
 		</dependency>
 		
 		<!-- shiro ehcache -->


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.0.

Signed-off-by: dependabot[bot] <support@github.com>